### PR TITLE
fix(messages): read Instant View webpage text

### DIFF
--- a/src/__tests__/message-webpage-text.test.ts
+++ b/src/__tests__/message-webpage-text.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import bigInt from "big-integer";
+import { Api } from "telegram/tl/index.js";
+import { TelegramService } from "../telegram-client.js";
+
+interface Internals {
+  client: unknown;
+  connected: boolean;
+}
+
+function makeService(messages: Api.Message[]): TelegramService {
+  const service = new TelegramService(1, "hash");
+  const internals = service as unknown as Internals;
+  internals.client = {
+    getMessages: async () => messages,
+  };
+  internals.connected = true;
+  return service;
+}
+
+function makeCachedPage(): Api.Page {
+  return new Api.Page({
+    url: "https://example.com/calls/10",
+    blocks: [
+      new Api.PageBlockTitle({ text: new Api.TextPlain({ text: "Call transcript" }) }),
+      new Api.PageBlockParagraph({
+        text: new Api.TextConcat({
+          texts: [
+            new Api.TextPlain({ text: "Operator " }),
+            new Api.TextBold({ text: new Api.TextPlain({ text: "never" }) }),
+            new Api.TextPlain({ text: " joined " }),
+            new Api.TextUrl({
+              text: new Api.TextPlain({ text: "the call" }),
+              url: "https://example.com/calls/10",
+              webpageId: bigInt(10),
+            }),
+            new Api.TextPlain({ text: "." }),
+          ],
+        }),
+      }),
+      new Api.PageBlockList({
+        items: [
+          new Api.PageListItemText({ text: new Api.TextPlain({ text: "No action" }) }),
+          new Api.PageListItemBlocks({
+            blocks: [
+              new Api.PageBlockParagraph({
+                text: new Api.TextPlain({ text: "Escalation pending" }),
+              }),
+            ],
+          }),
+        ],
+      }),
+    ],
+    photos: [],
+    documents: [],
+  });
+}
+
+function makeWebPageMessage(message = "", cachedPage?: Api.Page): Api.Message {
+  const webpage = new Api.WebPage({
+    id: bigInt(10),
+    url: "https://example.com/calls/10",
+    displayUrl: "example.com/calls/10",
+    hash: 0,
+    title: "Call transcript",
+    description: "The operator never joined the call.",
+    cachedPage,
+  });
+  return new Api.Message({
+    id: 864,
+    peerId: new Api.PeerUser({ userId: bigInt(1) }),
+    date: 1,
+    message,
+    media: new Api.MessageMediaWebPage({ webpage }),
+  });
+}
+
+describe("TelegramService.getMessages webpage text", () => {
+  it("reads rich text and nested blocks from an Instant View cached page", async () => {
+    const service = makeService([makeWebPageMessage("", makeCachedPage())]);
+
+    const [message] = await service.getMessages("@concierge", 1);
+
+    assert.strictEqual(
+      message.text,
+      "Call transcript\n\nOperator never joined the call.\n\n• No action\n• Escalation pending",
+    );
+    assert.deepStrictEqual(message.media, { type: "webpage" });
+  });
+
+  it("uses visible webpage title and description when the message body is empty", async () => {
+    const service = makeService([makeWebPageMessage()]);
+
+    const [message] = await service.getMessages("@concierge", 1);
+
+    assert.strictEqual(message.text, "Call transcript\n\nThe operator never joined the call.");
+    assert.deepStrictEqual(message.media, { type: "webpage" });
+  });
+
+  it("keeps an explicit message body instead of replacing it with preview text", async () => {
+    const service = makeService([makeWebPageMessage("Open the transcript")]);
+
+    const [message] = await service.getMessages("@concierge", 1);
+
+    assert.strictEqual(message.text, "Open the transcript");
+  });
+});

--- a/src/telegram-client.ts
+++ b/src/telegram-client.ts
@@ -1392,7 +1392,7 @@ export class TelegramService {
     if (!m || m.id !== messageId) return null;
     return {
       id: m.id,
-      text: m.message ?? "",
+      text: this.extractMessageText(m),
       sender: await this.resolveSenderName(m.senderId),
       date: new Date((m.date ?? 0) * 1000).toISOString(),
       media: this.extractMediaInfo(m.media),
@@ -1446,7 +1446,7 @@ export class TelegramService {
         .map((m) => ({
           id: m.id,
           date: new Date((m.date ?? 0) * 1000).toISOString(),
-          text: m.message ?? "",
+          text: this.extractMessageText(m),
           media: this.extractMediaInfo(m.media),
         }));
     }, `getScheduledMessages in ${chatId}`);
@@ -1492,7 +1492,7 @@ export class TelegramService {
           .filter((m): m is Api.Message => m instanceof Api.Message)
           .map(async (m) => ({
             id: m.id,
-            text: m.message ?? "",
+            text: this.extractMessageText(m),
             sender: await this.resolveSenderName(m.senderId),
             date: new Date((m.date ?? 0) * 1000).toISOString(),
             media: this.extractMediaInfo(m.media),
@@ -1553,7 +1553,7 @@ export class TelegramService {
           .filter((m): m is Api.Message => m instanceof Api.Message)
           .map(async (m) => ({
             id: m.id,
-            text: m.message ?? "",
+            text: this.extractMessageText(m),
             sender: await this.resolveSenderName(m.senderId),
             date: new Date((m.date ?? 0) * 1000).toISOString(),
             media: this.extractMediaInfo(m.media),
@@ -1610,7 +1610,7 @@ export class TelegramService {
           .filter((m): m is Api.Message => m instanceof Api.Message)
           .map(async (m) => ({
             id: m.id,
-            text: m.message ?? "",
+            text: this.extractMessageText(m),
             sender: await this.resolveSenderName(m.senderId),
             date: new Date((m.date ?? 0) * 1000).toISOString(),
             media: this.extractMediaInfo(m.media),
@@ -1880,6 +1880,140 @@ export class TelegramService {
     return { id: chatId, name: "Unknown", type: "unknown" };
   }
 
+  /** Flatten Telegram rich text while preserving the visible character order. */
+  private extractRichText(text: Api.TypeRichText): string {
+    if (text instanceof Api.TextPlain) return text.text;
+    if (text instanceof Api.TextConcat) {
+      return text.texts.map((part) => this.extractRichText(part)).join("");
+    }
+    if ("text" in text) return this.extractRichText(text.text);
+    return "";
+  }
+
+  private joinVisibleText(parts: Array<string | undefined>, separator = "\n\n"): string {
+    return parts
+      .map((part) => part?.trim())
+      .filter((part): part is string => Boolean(part))
+      .join(separator);
+  }
+
+  private extractPageCaption(caption: Api.TypePageCaption): string {
+    if (!(caption instanceof Api.PageCaption)) return "";
+    return this.joinVisibleText([this.extractRichText(caption.text), this.extractRichText(caption.credit)]);
+  }
+
+  /** Flatten the content Telegram renders in an Instant View page block. */
+  private extractPageBlock(block: Api.TypePageBlock): string {
+    if (block instanceof Api.PageBlockList) {
+      return block.items
+        .map((item) => {
+          const text =
+            item instanceof Api.PageListItemText
+              ? this.extractRichText(item.text)
+              : item instanceof Api.PageListItemBlocks
+                ? this.extractPageBlocks(item.blocks)
+                : "";
+          return text ? `• ${text}` : "";
+        })
+        .filter(Boolean)
+        .join("\n");
+    }
+
+    if (block instanceof Api.PageBlockOrderedList) {
+      return block.items
+        .map((item) => {
+          const text =
+            item instanceof Api.PageListOrderedItemText
+              ? this.extractRichText(item.text)
+              : item instanceof Api.PageListOrderedItemBlocks
+                ? this.extractPageBlocks(item.blocks)
+                : "";
+          return text ? `${item.num} ${text}`.trim() : "";
+        })
+        .filter(Boolean)
+        .join("\n");
+    }
+
+    if (block instanceof Api.PageBlockBlockquote || block instanceof Api.PageBlockPullquote) {
+      return this.joinVisibleText([this.extractRichText(block.text), this.extractRichText(block.caption)]);
+    }
+
+    if (block instanceof Api.PageBlockAuthorDate) return this.extractRichText(block.author);
+    if (block instanceof Api.PageBlockCover) return this.extractPageBlock(block.cover);
+
+    if (block instanceof Api.PageBlockEmbedPost) {
+      return this.joinVisibleText([
+        block.author,
+        this.extractPageBlocks(block.blocks),
+        this.extractPageCaption(block.caption),
+      ]);
+    }
+
+    if (block instanceof Api.PageBlockCollage || block instanceof Api.PageBlockSlideshow) {
+      return this.joinVisibleText([this.extractPageBlocks(block.items), this.extractPageCaption(block.caption)]);
+    }
+
+    if (block instanceof Api.PageBlockTable) {
+      const rows = block.rows
+        .map((row) =>
+          row.cells
+            .map((cell) => (cell.text ? this.extractRichText(cell.text) : ""))
+            .filter(Boolean)
+            .join("\t"),
+        )
+        .filter(Boolean)
+        .join("\n");
+      return this.joinVisibleText([this.extractRichText(block.title), rows]);
+    }
+
+    if (block instanceof Api.PageBlockDetails) {
+      return this.joinVisibleText([this.extractRichText(block.title), this.extractPageBlocks(block.blocks)]);
+    }
+
+    if (block instanceof Api.PageBlockRelatedArticles) {
+      const articles = block.articles
+        .map((article) => this.joinVisibleText([article.title, article.description, article.author], " — "))
+        .filter(Boolean)
+        .join("\n");
+      return this.joinVisibleText([this.extractRichText(block.title), articles]);
+    }
+
+    if (
+      block instanceof Api.PageBlockPhoto ||
+      block instanceof Api.PageBlockVideo ||
+      block instanceof Api.PageBlockEmbed ||
+      block instanceof Api.PageBlockAudio ||
+      block instanceof Api.PageBlockMap
+    ) {
+      return this.extractPageCaption(block.caption);
+    }
+
+    if ("text" in block) return this.extractRichText(block.text);
+    return "";
+  }
+
+  private extractPageBlocks(blocks: Api.TypePageBlock[]): string {
+    return this.joinVisibleText(blocks.map((block) => this.extractPageBlock(block)));
+  }
+
+  /** Return the text Telegram clients render for a message. */
+  private extractMessageText(message: Api.Message): string {
+    const text = message.message ?? "";
+    if (text.length > 0) return text;
+
+    const media = message.media;
+    if (media instanceof Api.MessageMediaWebPage && media.webpage instanceof Api.WebPage) {
+      const cachedPage = media.webpage.cachedPage;
+      if (cachedPage instanceof Api.Page) {
+        const cachedPageText = this.extractPageBlocks(cachedPage.blocks);
+        if (cachedPageText) return cachedPageText;
+      }
+      return this.joinVisibleText([media.webpage.title, media.webpage.description]);
+    }
+
+    return text;
+  }
+
   /** Extract media info from a message */
   private extractMediaInfo(
     media: Api.TypeMessageMedia | undefined,
@@ -1899,6 +2033,9 @@ export class TelegramService {
         else if (attr instanceof Api.DocumentAttributeFilename) fileName = attr.fileName;
       }
       return { type, fileName, size: doc.size?.toJSNumber?.() ?? Number(doc.size) };
+    }
+    if (media instanceof Api.MessageMediaWebPage) {
+      return { type: "webpage" };
     }
     return undefined;
   }
@@ -1953,7 +2090,7 @@ export class TelegramService {
     const results = await Promise.all(
       filtered.map(async (m) => ({
         id: m.id,
-        text: m.message ?? "",
+        text: this.extractMessageText(m),
         sender: await this.resolveSenderName(m.senderId),
         date: new Date((m.date ?? 0) * 1000).toISOString(),
         media: this.extractMediaInfo(m.media),
@@ -2116,7 +2253,7 @@ export class TelegramService {
 
         return {
           id: m.id,
-          text: m.message ?? "",
+          text: this.extractMessageText(m),
           sender: await this.resolveSenderName(m.senderId),
           date: new Date((m.date ?? 0) * 1000).toISOString(),
           chat: chatsMap.get(chatId) || { id: chatId, name: "Unknown", type: "unknown" },
@@ -2158,7 +2295,7 @@ export class TelegramService {
     const results = await Promise.all(
       filtered.map(async (m) => ({
         id: m.id,
-        text: m.message ?? "",
+        text: this.extractMessageText(m),
         sender: await this.resolveSenderName(m.senderId),
         date: new Date((m.date ?? 0) * 1000).toISOString(),
         media: this.extractMediaInfo(m.media),
@@ -3051,7 +3188,7 @@ export class TelegramService {
         .filter((m): m is Api.Message => m instanceof Api.Message)
         .map(async (m) => ({
           id: m.id,
-          text: m.message ?? "",
+          text: this.extractMessageText(m),
           sender: await this.resolveSenderName(m.senderId),
           date: new Date((m.date ?? 0) * 1000).toISOString(),
           media: this.extractMediaInfo(m.media),


### PR DESCRIPTION
## Summary

- return visible text for messages whose ordinary Telegram message field is empty but whose webpage contains an Instant View cached page
- recursively flatten rich text, lists, quotes, tables, captions, and nested page blocks
- use the same extraction across message-reading and search result paths, and report the media as `webpage`

## Root cause

Telegram can render a rich Instant View message entirely from `MessageMediaWebPage.webpage.cachedPage.blocks` while `Message.message` is empty. The MCP summaries only read `Message.message`, so those messages appeared blank even though Telegram Web displayed their full content.

## Tests

- `bunx tsx --test src/__tests__/message-webpage-text.test.ts` (3 pass)
- `bun run lint`
- `bun run typecheck`
- `bun run test` reaches 579 pass; the two existing `runclient-integration` cases fail only in the combined run and pass when that file is run alone.